### PR TITLE
Member function for `MzSpectrumPL` for centroiding

### DIFF
--- a/cpp/src/Proteolizard.cpp
+++ b/cpp/src/Proteolizard.cpp
@@ -49,6 +49,9 @@ PYBIND11_MODULE(libproteolizarddata, h) {
             .def("toResolution", [](MzSpectrumPL &self, int resolution){
                 return self.toResolution(resolution);
             })
+            .def("toCentroided", [](MzSpectrumPL &self, int baselineNoiseLevel, double sigma){
+                return self.toCentroided(baselineNoiseLevel,sigma);
+            })
 
             .def("windows",
                  [](MzSpectrumPL &self, double windowLength, bool overlapping, int minPeaks, int minIntensity) {

--- a/cpp/src/Spectrum.h
+++ b/cpp/src/Spectrum.h
@@ -21,6 +21,7 @@ public:
     [[nodiscard]] std::map<int, MzSpectrumPL> windows(double windowLength, bool overlapping, int minPeaks, int minIntensity) const;
     [[nodiscard]] std::pair<std::vector<int>, std::vector<MzSpectrumPL>> exportWindows(double windowLength, bool overlapping,
                                                                           int minPeaks, int minIntensity) const;
+    [[nodiscard]] MzSpectrumPL toCentroided(int baselineNoiseLevel, double sigma) const;
 
     friend MzSpectrumPL operator+(const MzSpectrumPL &leftSpec, const MzSpectrumPL &rightSpec);
 

--- a/python/proteolizarddata/data.py
+++ b/python/proteolizarddata/data.py
@@ -278,6 +278,13 @@ class MzSpectrum:
         """
         return MzSpectrum(self.spec_ptr.toResolution(resolution))
 
+    def to_centroided(self, baseline_noise_level: int, sigma: float):
+        """
+        :param sigma: distance cutoff value, maximal distance for two mzs
+            to be considered of same peak.
+        """
+        return MzSpectrum(self.spec_ptr.toCentroided(baseline_noise_level, sigma))
+
     def windows(self, window_length=10, overlapping=True, min_peaks=3, min_intensity=50):
         """
         :param window_length:
@@ -297,6 +304,7 @@ class MzSpectrum:
 
     def filter(self, mz_min=0, mz_max=2000, intensity_min=25):
         """
+        to ignore one limit, it can be set to -1
         :param mz_min:
         :param mz_max:
         :param intensity_min:


### PR DESCRIPTION
1. Implemented `MzSpectrumPL::toCentroided`
    + This function is supposed to mimic
      spectra centroiding of the FPGA of the mass
      spectrometer. However it remains unclear, if
      the FPGA operates like this.
    + `MzSpectrumPL::toCentroided` is supposed to be used for the generation
      of synthetic data
    + `MzSpectrumPL::toCentroided` is summing intensities
      of the profile to calculate the centroid intensity
    + first, all peaks below baseline noise level are discarded
    + then peaks are clustered based on a maximum mz distance