### PR TITLE
Unordered_map_usage

### DIFF
--- a/cpp/src/Proteolizard.cpp
+++ b/cpp/src/Proteolizard.cpp
@@ -43,6 +43,7 @@ PYBIND11_MODULE(libproteolizarddata, h) {
                 return py::array(py::cast(self.intensity));
             })
             .def(py::self + py::self)
+            .def(py::self += py::self)
             .def(py::self * float())
             .def(float() * py::self)
             .def("vectorize", [](MzSpectrumPL &self, int resolution) {

--- a/cpp/src/Spectrum.cpp
+++ b/cpp/src/Spectrum.cpp
@@ -4,14 +4,19 @@
 #include <unordered_map>
 
 MzSpectrumPL operator+(const MzSpectrumPL &leftSpec, const MzSpectrumPL &rightSpec){
+    MzSpectrumPL l = leftSpec;
+    return l += rightSpec;
 
+}
+
+MzSpectrumPL& MzSpectrumPL::operator+=(const MzSpectrumPL &rightSpec){
     std::unordered_map<double, int> sumMap;
 
-    // insert leftFrame values into map
-    for (auto it = leftSpec.mz.begin(); it != leftSpec.mz.end(); ++it) {
-        auto i = std::distance(leftSpec.mz.begin(), it);
-        auto index = leftSpec.mz[i];
-        auto intensity = leftSpec.intensity[i];
+    // insert this's values into map
+    for (auto it = this->mz.begin(); it != this->mz.end(); ++it) {
+        auto i = std::distance(this->mz.begin(), it);
+        auto index = this->mz[i];
+        auto intensity = this->intensity[i];
         sumMap[index] = intensity;
     }
 
@@ -39,8 +44,10 @@ MzSpectrumPL operator+(const MzSpectrumPL &leftSpec, const MzSpectrumPL &rightSp
         retIndices.push_back(key);
         retValues.push_back(value);
     }
+    this->mz = retIndices;
+    this->intensity = retValues;
 
-    return {leftSpec.frameId, leftSpec.scanId, retIndices, retValues};
+    return *this;
 }
 
 MzSpectrumPL operator*(const MzSpectrumPL &leftSpec, const float scalar){

--- a/cpp/src/Spectrum.cpp
+++ b/cpp/src/Spectrum.cpp
@@ -1,10 +1,11 @@
 #include "Spectrum.h"
 #include <numeric>
 #include <cmath>
+#include <unordered_map>
 
 MzSpectrumPL operator+(const MzSpectrumPL &leftSpec, const MzSpectrumPL &rightSpec){
 
-    std::map<double, int> sumMap;
+    std::unordered_map<double, int> sumMap;
 
     // insert leftFrame values into map
     for (auto it = leftSpec.mz.begin(); it != leftSpec.mz.end(); ++it) {
@@ -112,7 +113,7 @@ MzSpectrumPL MzSpectrumPL::filter(double mzMin, double mzMax, int intensityMin) 
 
 MzSpectrumPL MzSpectrumPL::toResolution(int resolution) const{
 
-    std::map<int, int> intensityMap;
+    std::unordered_map<int, int> intensityMap;
     double factor = pow(10.0, resolution);
 
     std::vector<double> resMz;

--- a/cpp/src/Spectrum.h
+++ b/cpp/src/Spectrum.h
@@ -26,6 +26,7 @@ public:
     friend MzSpectrumPL operator+(const MzSpectrumPL &leftSpec, const MzSpectrumPL &rightSpec);
     friend MzSpectrumPL operator*(const MzSpectrumPL &Spec, const float scalar);
     friend MzSpectrumPL operator*(const float scalar, const MzSpectrumPL &Spec);
+    MzSpectrumPL& operator+=(const MzSpectrumPL &rightSpec);
     int frameId{};
     // double retentionTime{};
     int scanId{};

--- a/python/proteolizarddata/data.py
+++ b/python/proteolizarddata/data.py
@@ -261,6 +261,12 @@ class MzSpectrum:
         """
         return MzSpectrum(self.spec_ptr + other.spec_ptr)
 
+    def __iadd__(self, other):
+        """
+        :param other:
+        """
+        self.spec_ptr += other.spec_ptr
+        return self
     def vectorize(self, resolution: int = 2):
         """
         :param resolution:


### PR DESCRIPTION
* use std::unordered_map instead of std::ordered_map for spectra addition and `to.resolution`.
* += operator for `MzSpectra`