### PR TITLE
push for MzSpectrumPL

### DIFF
--- a/cpp/src/Proteolizard.cpp
+++ b/cpp/src/Proteolizard.cpp
@@ -58,7 +58,9 @@ PYBIND11_MODULE(libproteolizarddata, h) {
             .def("toCentroided", [](MzSpectrumPL &self, int baselineNoiseLevel, double sigma){
                 return self.toCentroided(baselineNoiseLevel,sigma);
             })
-
+            .def("push", [](MzSpectrumPL &self, MzSpectrumPL &other){
+                return self.push(other);
+            })
             .def("windows",
                  [](MzSpectrumPL &self, double windowLength, bool overlapping, int minPeaks, int minIntensity) {
                 auto p = self.exportWindows(windowLength, overlapping, minPeaks, minIntensity);

--- a/cpp/src/Spectrum.cpp
+++ b/cpp/src/Spectrum.cpp
@@ -186,8 +186,12 @@ MzSpectrumPL MzSpectrumPL::toCentroided(int baselineNoiseLevel, double sigma) co
 
 
     return MzSpectrumPL{this->frameId, this->scanId, centMz, centI};
+}
 
-
+MzSpectrumPL& MzSpectrumPL::push(MzSpectrumPL& other){
+    this->mz.insert(this->mz.end(), other.mz.begin(), other.mz.end());
+    this->intensity.insert(this->intensity.end(), other.intensity.begin(), other.intensity.end());
+    return *this;
 }
 
 /**

--- a/cpp/src/Spectrum.h
+++ b/cpp/src/Spectrum.h
@@ -22,7 +22,7 @@ public:
     [[nodiscard]] std::pair<std::vector<int>, std::vector<MzSpectrumPL>> exportWindows(double windowLength, bool overlapping,
                                                                           int minPeaks, int minIntensity) const;
     [[nodiscard]] MzSpectrumPL toCentroided(int baselineNoiseLevel, double sigma) const;
-
+    [[nodiscard]] MzSpectrumPL& push(MzSpectrumPL& other);
     friend MzSpectrumPL operator+(const MzSpectrumPL &leftSpec, const MzSpectrumPL &rightSpec);
     friend MzSpectrumPL operator*(const MzSpectrumPL &Spec, const float scalar);
     friend MzSpectrumPL operator*(const float scalar, const MzSpectrumPL &Spec);
@@ -36,5 +36,6 @@ public:
 };
 
 MzSpectrumPL operator+(const MzSpectrumPL &leftSpec, const MzSpectrumPL &rightSpec);
-
+MzSpectrumPL operator*(const MzSpectrumPL &leftSpec, const float scalar);
+MzSpectrumPL operator*(const float scalar, const MzSpectrumPL &rightSpec);
 #endif //CPP_SPECTRUM_H

--- a/python/proteolizarddata/data.py
+++ b/python/proteolizarddata/data.py
@@ -286,6 +286,7 @@ class MzSpectrum:
         """
         self.spec_ptr += other.spec_ptr
         return self
+
     def vectorize(self, resolution: int = 2):
         """
         :param resolution:
@@ -306,6 +307,16 @@ class MzSpectrum:
             to be considered of same peak.
         """
         return MzSpectrum(self.spec_ptr.toCentroided(baseline_noise_level, sigma))
+
+    def push(self, other):
+        """
+        Append mz and intensity values of
+        an other MzSpectra without mapping.
+
+        :param other: MzSpectrum to push to self
+        :type other: MzSpectrum
+        """
+        return MzSpectrum(self.spec_ptr.push(other.spec_ptr))
 
     def windows(self, window_length=10, overlapping=True, min_peaks=3, min_intensity=50):
         """


### PR DESCRIPTION
1. Implemented `MzSpectrumPL::push` that just
    data from one spectrum to the other.

    + This is useful during the assembly
      of spectra in proteolizards synthetic data
      framework