### PR TITLE
handle for synthetic data

### DIFF
--- a/cpp/src/Proteolizard.cpp
+++ b/cpp/src/Proteolizard.cpp
@@ -25,7 +25,7 @@ PYBIND11_MODULE(libproteolizarddata, h) {
 
             // -------------- CONSTRUCTOR ---------------
             .def(py::init<int &, int &, std::vector<double> &, std::vector<int> &>())
-
+            .def(py::init<std::vector<MzSpectrumPL> &,int &, bool &, int &, double &>())
             // -------------- MEMBER ---------------
             .def("getFrameId", [](MzSpectrumPL &self) {
                 return self.frameId;

--- a/cpp/src/Spectrum.cpp
+++ b/cpp/src/Spectrum.cpp
@@ -64,6 +64,32 @@ MzSpectrumPL operator*(const float scalar, const MzSpectrumPL &rightSpec){
 MzSpectrumPL::MzSpectrumPL(int frame, int scan, std::vector<double> m, std::vector<int> i):
     frameId(frame), scanId(scan), mz(std::move(m)), intensity(std::move(i)) {}
 
+MzSpectrumPL::MzSpectrumPL(std::vector<MzSpectrumPL> &spectra, int resolution, bool centroid, int baselineNoiseLevel, double sigma){
+    size_t to_allocate = 0;
+    for (auto& spectrum : spectra){
+        to_allocate += spectrum.mz.size();
+    }
+
+    this->mz.reserve(to_allocate);
+    this->intensity.reserve(to_allocate);
+    for (auto& spectrum : spectra){
+        this->push(spectrum);
+    }
+    MzSpectrumPL tmp;
+    if (centroid){
+        tmp = this->toResolution(resolution).toCentroided(baselineNoiseLevel, sigma);
+    }
+    else{
+        tmp = this->toResolution(resolution);
+    }
+    this -> mz = std::move(tmp.mz);
+    this -> intensity = std::move(tmp.intensity);
+    this -> scanId = spectra[0].scanId;
+    this -> frameId = spectra[0].frameId;
+}
+
+
+
 MzVectorPL MzSpectrumPL::vectorize(int resolution) const{
 
     // auto tmp = this->toResolution(resolution);

--- a/cpp/src/Spectrum.h
+++ b/cpp/src/Spectrum.h
@@ -13,11 +13,10 @@ public:
     // constructors
     MzSpectrumPL()= default;
     MzSpectrumPL(int frame, int scan, std::vector<double> m, std::vector<int> i);
-
+    MzSpectrumPL(std::vector<MzSpectrumPL> &spectra, int resolution, bool centroid, int baselineNoiseLevel, double sigma);
     [[nodiscard]] MzSpectrumPL toResolution(int resolution) const;
     [[nodiscard]] MzVectorPL vectorize(int resolution) const;
     [[nodiscard]] MzSpectrumPL filter(double mzMin, double mzMax, int intensityMin) const;
-
     [[nodiscard]] std::map<int, MzSpectrumPL> windows(double windowLength, bool overlapping, int minPeaks, int minIntensity) const;
     [[nodiscard]] std::pair<std::vector<int>, std::vector<MzSpectrumPL>> exportWindows(double windowLength, bool overlapping,
                                                                           int minPeaks, int minIntensity) const;


### PR DESCRIPTION
This PR adds two things:

1. `PyTimsSyntheticHandle` for loading simulated data 
      saved in parquet format
2. New class method for `MzSpectrum` for generating 
     spectrum from list of spectra.